### PR TITLE
Add Redis caching support and update environment configuration

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -28,7 +28,7 @@ def dashboard(request):
 ...
 
 ```python
-from src.core import views
+from core import views
 
 ...
 

--- a/.env.template
+++ b/.env.template
@@ -14,3 +14,5 @@ AWS_SECRET_ACCESS_KEY=op://dev/ses/secret_access_key
 AWS_DEFAULT_REGION=op://dev/ses/region
 
 SENTRY_DSN=op://dev/sentry/sandbox_dsn
+REDIS_URL=op://dev/redis/url
+CACHE_PREFIX=django_cache

--- a/.env.template
+++ b/.env.template
@@ -16,3 +16,5 @@ AWS_DEFAULT_REGION=op://dev/ses/region
 SENTRY_DSN=op://dev/sentry/sandbox_dsn
 REDIS_URL=op://dev/redis/url
 CACHE_PREFIX=django_cache
+
+PYTHONPATH=src

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY pyproject.toml uv.lock ./
 
 RUN uv sync
 
-# Set Python path to include the src directory
 ENV PYTHONPATH=src
 ENV PYTHONUNBUFFERED=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim as base
 
 WORKDIR /app
 
@@ -13,11 +13,18 @@ COPY pyproject.toml uv.lock ./
 
 RUN uv sync
 
+# Set Python path to include the src directory
+ENV PYTHONPATH=src
+ENV PYTHONUNBUFFERED=1
+
 COPY src/ ./src/
 COPY manage.py ./
 
-ENV PYTHONUNBUFFERED=1
+# Worker stage
+FROM base as worker
+CMD ["uv", "run", "python", "manage.py", "rqworker", "default"]
 
+# Web stage
+FROM base as web
 RUN uv run python manage.py collectstatic --noinput
-
 CMD ["uv", "run", "granian", "--host", "0.0.0.0", "--port", "8000", "--interface", "wsgi", "src.wsgi:application"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   backend:
     build:
       context: .
+      target: web
     ports:
       - "${BACKEND_PORT:-8000}:8000"
     environment:
@@ -13,8 +14,26 @@ services:
       AWS_REGION: ${AWS_REGION:-us-east-2}
       DEBUG: ${DEBUG:-true}
       LOG_REQUESTS: ${LOG_REQUESTS:-true}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
     depends_on:
       - postgres
+      - redis
+
+  worker:
+    build:
+      context: .
+      target: worker
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/postgres}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+    depends_on:
+      - postgres
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
 
   postgres:
     image: postgres:16
@@ -30,6 +49,7 @@ services:
   migrations:
     build:
       context: .
+      target: web
     command: uv run manage.py migrate
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,5 @@ dependencies = [
     "django-widget-tweaks>=1.5.0",
     "django-unfold>=0.50.0",
     "django-debug-toolbar>=5.0.1",
+    "django-redis>=5.4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,5 @@ dependencies = [
     "django-unfold>=0.50.0",
     "django-debug-toolbar>=5.0.1",
     "django-redis>=5.4.0",
+    "django-rq>=3.0.0",
 ]

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -7,8 +7,10 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from ninja import NinjaAPI, Router
 from ninja.responses import Response
 from ninja.security import django_auth
+from django_rq import job
 
-from src.core.models import StockTicker
+from core.models import StockTicker
+from utils import test_rq_job
 
 from .schemas import AddOutput, GreetOutput, StockTickerOut
 
@@ -68,3 +70,13 @@ def get_stocks(request, symbol: Optional[str] = None):
 @v1.get("/sentry-debug")
 def sentry_debug(request):
     raise Exception("This is a test exception for Sentry")
+
+
+
+
+@v1.get("/test-rq", auth=None)
+def test_rq(request):
+
+    test_rq_job.delay()
+
+    return Response({"message": "Job queued"})

--- a/src/core/apps.py
+++ b/src/core/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
-    name = "src.core"
+    name = "core"

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -4,6 +4,7 @@ from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 from django.urls import path
 from django.contrib.auth import get_user_model
 from datetime import date
+from django_redis import get_redis_connection
 
 from src.core.models import StockTicker
 
@@ -18,6 +19,9 @@ class ViewTests(TestCase):
             password="testpass123",
             email="test@example.com",  # Required for custom User model
         )
+
+    def tearDown(self):
+        get_redis_connection("default").flushall()
 
     def test_landing_page(self):
         """Test that landing page is accessible"""
@@ -70,6 +74,9 @@ class APITests(TestCase):
             market_cap=3120000000000,
             date=date.today(),
         )
+
+    def tearDown(self):
+        get_redis_connection("default").flushall()
 
     def test_csrf_token_endpoint(self):
         """Test CSRF token endpoint"""

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from datetime import date
 from django_redis import get_redis_connection
 
-from src.core.models import StockTicker
+from core.models import StockTicker
 
 User = get_user_model()
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -21,6 +21,8 @@ from dj_database_url import parse as db_url
 from django.core.management.utils import get_random_secret_key
 from loguru import logger
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
+from sentry_sdk.integrations.rq import RqIntegration
 
 
 def parse_comma_separated_list(string, sep=","):
@@ -103,7 +105,7 @@ if SENTRY_DSN:
     glitchtip_environment = "development" if DEBUG else "production"
     sentry_sdk.init(
         dsn=SENTRY_DSN,
-        integrations=[DjangoIntegration()],
+        integrations=[DjangoIntegration(), RedisIntegration(), RqIntegration(),],
         auto_session_tracking=False,
         traces_sample_rate=0.01,
         release="1.0.0",
@@ -163,6 +165,7 @@ INSTALLED_APPS = [
     "django_browser_reload",
     "widget_tweaks",
     "debug_toolbar",
+    "django_rq",
     "src.core",
 ]
 
@@ -218,12 +221,19 @@ CACHES = {
     }
 }
 
+RQ_QUEUES = {
+    "default": {
+        "USE_REDIS_CACHE": "default",
+    }
+}
+
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
 
 DJANGO_REDIS_IGNORE_EXCEPTIONS = config("DJANGO_REDIS_IGNORE_EXCEPTIONS", default=True, cast=bool)
 DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = config("DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS", default=True, cast=bool)
 
+RQ_SHOW_ADMIN_LINK = True
 
 ROOT_URLCONF = "src.urls"
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -201,14 +201,29 @@ MIDDLEWARE = [
 if LOG_REQUESTS:
     MIDDLEWARE.append("src.core.middleware.RequestLoggingMiddleware")
 
+REDIS_URL = config("REDIS_URL", default="redis://localhost:6379")
+CACHE_PREFIX = config("CACHE_PREFIX", default="django_cache")
+
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "django_cache",
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"{REDIS_URL}/0",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",
+        },
         # set the cache timeout to 30 days
         "TIMEOUT": 60 * 60 * 24 * 30,
+        "KEY_PREFIX": CACHE_PREFIX,
     }
 }
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
+
+DJANGO_REDIS_IGNORE_EXCEPTIONS = config("DJANGO_REDIS_IGNORE_EXCEPTIONS", default=True, cast=bool)
+DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = config("DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS", default=True, cast=bool)
+
 
 ROOT_URLCONF = "src.urls"
 

--- a/src/urls.py
+++ b/src/urls.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 from django.urls import path, include
 from debug_toolbar.toolbar import debug_toolbar_urls
 
-from src.core import views
+from core import views
 from .api import api
 
 urlpatterns = [
@@ -28,6 +28,7 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("_allauth/", include("allauth.headless.urls")),
     path("__reload__/", include("django_browser_reload.urls")),
+    path("django-rq/", include("django_rq.urls")),
 ]
 
 urlpatterns += views.route.patterns

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,5 @@
+from django_rq import job
+
+@job
+def test_rq_job():
+    print("Hello, world!")

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "django-debug-toolbar" },
     { name = "django-ninja" },
+    { name = "django-redis" },
     { name = "django-unfold" },
     { name = "django-widget-tweaks" },
     { name = "djecorator" },
@@ -57,6 +58,7 @@ requires-dist = [
     { name = "django-cors-headers", specifier = ">=4.4.0" },
     { name = "django-debug-toolbar", specifier = ">=5.0.1" },
     { name = "django-ninja", specifier = ">=1.3.0" },
+    { name = "django-redis", specifier = ">=5.4.0" },
     { name = "django-unfold", specifier = ">=0.50.0" },
     { name = "django-widget-tweaks", specifier = ">=1.5.0" },
     { name = "djecorator", specifier = ">=1.2.0" },
@@ -67,9 +69,6 @@ requires-dist = [
     { name = "sentry-sdk", specifier = ">=2.20.0" },
     { name = "whitenoise", specifier = ">=6.8.2" },
 ]
-
-[package.metadata.requires-dev]
-dev = []
 
 [[package]]
 name = "boto3"
@@ -261,6 +260,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-redis"
+version = "5.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/9d/2272742fdd9d0a9f0b28cd995b0539430c9467a2192e4de2cea9ea6ad38c/django-redis-5.4.0.tar.gz", hash = "sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42", size = 52567 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/f1/63caad7c9222c26a62082f4f777de26389233b7574629996098bf6d25a4d/django_redis-5.4.0-py3-none-any.whl", hash = "sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b", size = 31119 },
+]
+
+[[package]]
 name = "django-unfold"
 version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
@@ -438,6 +450,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/97/373dcd5844ec0ea5893e13c39a2c67e7537987ad8de3842fe078db4582fa/python-decouple-3.8.tar.gz", hash = "sha256:ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f", size = 9612 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/d4/9193206c4563ec771faf2ccf54815ca7918529fe81f6adb22ee6d0e06622/python_decouple-3.8-py3-none-any.whl", hash = "sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66", size = 9947 },
+]
+
+[[package]]
+name = "redis"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/da/d283a37303a995cd36f8b92db85135153dc4f7a8e4441aa827721b442cfb/redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f", size = 4608355 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/5f/fa26b9b2672cbe30e07d9a5bdf39cf16e3b80b42916757c5f92bca88e4ba/redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4", size = 261502 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,7 @@ dependencies = [
     { name = "django-debug-toolbar" },
     { name = "django-ninja" },
     { name = "django-redis" },
+    { name = "django-rq" },
     { name = "django-unfold" },
     { name = "django-widget-tweaks" },
     { name = "djecorator" },
@@ -59,6 +60,7 @@ requires-dist = [
     { name = "django-debug-toolbar", specifier = ">=5.0.1" },
     { name = "django-ninja", specifier = ">=1.3.0" },
     { name = "django-redis", specifier = ">=5.4.0" },
+    { name = "django-rq", specifier = ">=3.0.0" },
     { name = "django-unfold", specifier = ">=0.50.0" },
     { name = "django-widget-tweaks", specifier = ">=1.5.0" },
     { name = "djecorator", specifier = ">=1.2.0" },
@@ -273,6 +275,20 @@ wheels = [
 ]
 
 [[package]]
+name = "django-rq"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "redis" },
+    { name = "rq" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/71/0412cc1bd0f4026e727ad9fa8f407a2225b6ce593e15ed6fcccebeef50ef/django-rq-3.0.0.tar.gz", hash = "sha256:7bdadb85d9909c118cf1ee1b9bdd1a74ebf141bf8f3c2de2409fcac6080f67ac", size = 53356 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/9a/6a9cdc19805c31019021f582728de5493ef4381c391434f64af6e4b5121c/django_rq-3.0.0-py2.py3-none-any.whl", hash = "sha256:bd2ef287a28301f64c4282293648e4f8c6076dd895a545c9c6b98bde4a82a4ce", size = 64432 },
+]
+
+[[package]]
 name = "django-unfold"
 version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
@@ -474,6 +490,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+]
+
+[[package]]
+name = "rq"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/e6/1858493e933622ba4371a046c882596c991964b7345a6c77637a1efe7833/rq-2.2.0.tar.gz", hash = "sha256:b636760f1e4c183022031c142faa0483e687885824e9732ba2953f994104e203", size = 645030 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/1a/0eae7e1bb355ec7f7114afbf7de56c9c0b8ac94449a8d4aa06c527db6596/rq-2.2.0-py3-none-any.whl", hash = "sha256:dacbfe1ccb79a45c8cd95dec7951620679fa0195570b63da3f9347622d33accc", size = 98047 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Added REDIS_URL and CACHE_PREFIX to .env.template for Redis configuration.
- Updated pyproject.toml and uv.lock to include django-redis as a dependency.
- Modified settings.py to configure Django caching with Redis and set session management to use cache.
- Enhanced tests.py to flush Redis after tests for a clean state.