### PR TITLE
Update RQ worker commands in Dockerfile and justfile to include scheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY manage.py ./
 
 # Worker stage
 FROM base AS worker
-CMD ["uv", "run", "python", "manage.py", "rqworker", "default"]
+CMD ["uv", "run", "python", "manage.py", "rqworker", "default", "--with-scheduler"]
 
 # Web stage
 FROM base AS web

--- a/justfile
+++ b/justfile
@@ -57,7 +57,7 @@ test:
 
 # run rq worker
 worker:
-    uv run python manage.py rqworker default
+    uv run python manage.py rqworker default --with-scheduler
 
 # view rq stats
 @rqstats:

--- a/src/api/v1/rq/router.py
+++ b/src/api/v1/rq/router.py
@@ -1,10 +1,11 @@
 import random
 import time
+from datetime import datetime, timedelta
 from pprint import pprint
 
 import rq
 from django_redis import get_redis_connection
-from django_rq import job
+from django_rq import job, get_queue
 from ninja import Router
 
 from .schemas import JobResult
@@ -20,6 +21,12 @@ def test_rq_job():
     time.sleep(seconds)
     result = {"message": "Job completed", "seconds": seconds}
     pprint(result)
+
+    # Schedule the next run in 5 seconds
+    queue = get_queue("default")
+    next_run = datetime.now() + timedelta(seconds=5)
+    queue.enqueue_at(next_run, test_rq_job)
+
     return result
 
 


### PR DESCRIPTION
- Modified the Dockerfile and justfile to add the '--with-scheduler' option to the RQ worker command, enabling scheduled job execution.
- Enhanced the job handling in router.py to schedule the next job run, improving background task management.