### PR TITLE
Throwaway test PR: collapse blank line in copier.yml

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -2,7 +2,6 @@ _min_copier_version: "9.0.0"
 
 _subdirectory: template
 
-
 _exclude:
   - ".git"
   - "__pycache__"


### PR DESCRIPTION
## Summary
- Throwaway PR opened as a test of the workflow.
- Removes a stray double blank line above `_exclude:` in `copier.yml` — pure formatting, no behavior change.

## Test plan
- [ ] CI passes (no logic changed)